### PR TITLE
Add support for service account annotations to helm chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ helm repo add sops https://isindir.github.io/sops-secrets-operator/
 kubectl apply -f config/crd/bases/isindir.github.com_sopssecrets.yaml
 ```
 > **NOTE:** to grant access to aws for `sops-secret-operator` -
-> [kiam](https://github.com/uswitch/kiam) or [kube2iam](https://github.com/jtblin/kube2iam) can be used.
+> [kiam](https://github.com/uswitch/kiam), [kube2iam](https://github.com/jtblin/kube2iam) or [IAM roles for service accounts](https://docs.aws.amazon.com/eks/latest/userguide/specify-service-account-role.html) can be used.
 
 * Deploy helm chart:
 

--- a/chart/helm2/sops-secrets-operator/README.md
+++ b/chart/helm2/sops-secrets-operator/README.md
@@ -15,7 +15,7 @@ $ helm upgrade --install sops chart/sops-secrets-operator/ \
 
 > where `custom.values.yaml` must customise deployment and configure access to Cloud KMS
 
-* AWS is supported via `kiam` namespace and pod annotations
+* AWS is supported via `kiam` namespace and pod annotations or via [IAM roles for service accounts](https://docs.aws.amazon.com/eks/latest/userguide/specify-service-account-role.html)
 * GCP is supported via service account secret which allows decryption using GCP KMS
 * GPG is supported via secrets with GPG configuration
 * **TODO:** Azure support

--- a/chart/helm2/sops-secrets-operator/templates/service_account.yaml
+++ b/chart/helm2/sops-secrets-operator/templates/service_account.yaml
@@ -3,6 +3,10 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ include "sops-secrets-operator.fullname" . }}
+{{- with .Values.serviceAccount.annotations }}
+  annotations:
+{{ toYaml . | indent 4 }}
+{{- end }}
   labels:
 {{ include "sops-secrets-operator.labels" . | indent 4 }}
 {{- end }}

--- a/chart/helm2/sops-secrets-operator/values.yaml
+++ b/chart/helm2/sops-secrets-operator/values.yaml
@@ -16,6 +16,9 @@ fullnameOverride: ""  # Overrides auto-generated long resource name
 # aws
 podAnnotations: {}  # Annotations to be added to operator pod
 
+serviceAccount:
+  annotations: {} # Annotations to be added to the service account
+
 gpg:
   enabled: false  # If `true` GCP secret will be created from provided value and mounted as environment variable
   secret1: gpg1  # Name of the secret to create - will override default secret name if specified

--- a/chart/helm3/sops-secrets-operator/README.md
+++ b/chart/helm3/sops-secrets-operator/README.md
@@ -15,7 +15,7 @@ $ helm upgrade --install sops chart/sops-secrets-operator/ \
 
 > where `custom.values.yaml` must customise deployment and configure access to Cloud KMS
 
-* AWS is supported via `kiam` namespace and pod annotations
+* AWS is supported via `kiam` namespace and pod annotations or via [IAM roles for service accounts](https://docs.aws.amazon.com/eks/latest/userguide/specify-service-account-role.html)
 * GCP is supported via service account secret which allows decryption using GCP KMS
 * GPG is supported via secrets with GPG configuration
 * **TODO:** Azure support

--- a/chart/helm3/sops-secrets-operator/templates/service_account.yaml
+++ b/chart/helm3/sops-secrets-operator/templates/service_account.yaml
@@ -2,6 +2,10 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
+{{- with .Values.serviceAccount.annotations }}
+  annotations:
+{{ toYaml . | indent 4 }}
+{{- end }}
   name: {{ include "sops-secrets-operator.fullname" . }}
   labels:
 {{ include "sops-secrets-operator.labels" . | indent 4 }}

--- a/chart/helm3/sops-secrets-operator/values.yaml
+++ b/chart/helm3/sops-secrets-operator/values.yaml
@@ -16,6 +16,9 @@ fullnameOverride: ""  # Overrides auto-generated long resource name
 # aws
 podAnnotations: {}  # Annotations to be added to operator pod
 
+serviceAccount:
+  annotations: {} # Annotations to be added to the service account
+
 gpg:
   enabled: false  # If `true` GCP secret will be created from provided value and mounted as environment variable
   secret1: gpg1  # Name of the secret to create - will override default secret name if specified


### PR DESCRIPTION
Add the option to annotate service accounts to helm charts. 

#### What this PR does / why we need it:

Although service account annotations have other uses this change is motivated by the desire to support IAM roles for service accounts - which is first party alternative to kiam and kube2iam.

To enable support the service account used by the pod must be annotated with the IAM role being used.
