### PR TITLE
Remove duplicate labels from helm 3 templates

### DIFF
--- a/chart/helm3/sops-secrets-operator/templates/cluster_role.yaml
+++ b/chart/helm3/sops-secrets-operator/templates/cluster_role.yaml
@@ -5,8 +5,6 @@ metadata:
   name: {{ include "sops-secrets-operator.fullname" . }}
   labels:
 {{ include "sops-secrets-operator.labels" . | indent 4 }}
-    app.kubernetes.io/name: {{ include "sops-secrets-operator.name" . }}
-    app.kubernetes.io/instance: {{ .Release.Name }}
 rules:
 - apiGroups:
   - ""

--- a/chart/helm3/sops-secrets-operator/templates/cluster_role_binding.yaml
+++ b/chart/helm3/sops-secrets-operator/templates/cluster_role_binding.yaml
@@ -5,8 +5,6 @@ metadata:
   name: {{ include "sops-secrets-operator.fullname" . }}
   labels:
 {{ include "sops-secrets-operator.labels" . | indent 4 }}
-    app.kubernetes.io/name: {{ include "sops-secrets-operator.name" . }}
-    app.kubernetes.io/instance: {{ .Release.Name }}
 subjects:
 - kind: ServiceAccount
   name: {{ include "sops-secrets-operator.fullname" . }}

--- a/chart/helm3/sops-secrets-operator/templates/operator.yaml
+++ b/chart/helm3/sops-secrets-operator/templates/operator.yaml
@@ -4,8 +4,6 @@ metadata:
   name: {{ include "sops-secrets-operator.fullname" . }}
   labels:
 {{ include "sops-secrets-operator.labels" . | indent 4 }}
-    app.kubernetes.io/name: {{ template "sops-secrets-operator.name" . }}
-    app.kubernetes.io/instance: {{ .Release.Name }}
 spec:
   replicas: {{ .Values.replicaCount }}
   selector:

--- a/chart/helm3/sops-secrets-operator/templates/service_account.yaml
+++ b/chart/helm3/sops-secrets-operator/templates/service_account.yaml
@@ -9,6 +9,4 @@ metadata:
   name: {{ include "sops-secrets-operator.fullname" . }}
   labels:
 {{ include "sops-secrets-operator.labels" . | indent 4 }}
-    app.kubernetes.io/name: {{ include "sops-secrets-operator.name" . }}
-    app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end }}


### PR DESCRIPTION
#### What this PR does / why we need it:

The helm3 templates currently add the `app.kubernetes.io/name` and
`app.kubernetes.io/instance` labels to each resource via a hardcoded
label in each resources template and via the template function
`ops-secrets-operator.labels`. Since this change just removes the
duplicates it should effectively be a no-op.

The duplicates don't cause any issues AFAIK, just minor cleanup.