### PR TITLE
feat: add Azure KeyVault support to Helm charts

### DIFF
--- a/chart/helm2/sops-secrets-operator/README.md
+++ b/chart/helm2/sops-secrets-operator/README.md
@@ -18,7 +18,7 @@ $ helm upgrade --install sops chart/sops-secrets-operator/ \
 * AWS is supported via `kiam` namespace and pod annotations or via [IAM roles for service accounts](https://docs.aws.amazon.com/eks/latest/userguide/specify-service-account-role.html)
 * GCP is supported via service account secret which allows decryption using GCP KMS
 * GPG is supported via secrets with GPG configuration
-* **TODO:** Azure support
+* Azure is supported via a Service principal plus a secret
 
 ## Introduction
 

--- a/chart/helm2/sops-secrets-operator/README.md
+++ b/chart/helm2/sops-secrets-operator/README.md
@@ -57,6 +57,14 @@ gcp:
 * Apply `sops-secrets-operator` CRD
 * Deploy helm chart specifying extra values file
 
+### Azure
+
+* Create a KeyVault if you don't have one already
+* Create a Key in that KeyVault
+* Create Service principal with permissions to use the key for Encryption/Decryption
+  * follow the [SOPS documentation](https://github.com/mozilla/sops#encrypting-using-azure-key-vault)
+* Either put Tenant ID, Client ID and Client Secret for the Service Principal in your custom values.yaml file or create a Kubernetes Secret with the same information and put the name of that secret in your values.yaml. Enable Azure in the Helm Chart by setting `azure.enabled: true` in values.yaml.
+
 ## Uninstalling the Chart
 
 To uninstall/delete the `my-release` deployment:
@@ -87,6 +95,11 @@ The following table lists the configurable parameters of the Sops-secrets-operat
 | `gcp.enabled` | Node labels for operator pod assignment | `false` |
 | `gcp.svcAccSecretCustomName` | Name of the secret to create - will override default secret name if specified | `""` |
 | `gcp.svcAccSecret` | If `gcp.enabled` is `true`, this value must be specified as gcp service account secret json payload | `""` |
+| `azure.enabled` | If `true` azure secret will used/created depending on other values set. | `false` |
+| `azure.tenantId`| Tenant ID of the Azure Service principal to use for Key access | `''` |
+| `azure.clientId`| Client (Application) ID of the Azure Service principal to use for Key access | `''` |
+| `azure.clientSecret`| Client Secret of the Azure Service principal to use for Key access | `''` |
+| `azure.existingSecretName`| If set the named secret will be used to find the Azure SP credentials. | `''` |
 | `resources` | Operator container resources | `{}` |
 | `nodeSelector` | Node selector to use for pod configuration | `{}` |
 | `securityContext.enabled` | Enable securitycontext | `false` |

--- a/chart/helm2/sops-secrets-operator/templates/azure_secret.yaml
+++ b/chart/helm2/sops-secrets-operator/templates/azure_secret.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.azure.enabled (not .Values.azure.svcAccExistingSecretName) }}
+{{- if and .Values.azure.enabled (not .Values.azure.existingSecretName) }}
 kind: Secret
 apiVersion: v1
 metadata:
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/instance: {{ .Release.Name }}
 type: Opaque
 stringData:
-  tenantId: {{ .Values.azure.svcAccTenantId }}
-  clientId: {{ .Values.azure.svcAccClientId }}
-  clientSecret: {{ .Values.azure.svcAccClientSecret }}
+  tenantId: {{ .Values.azure.tenantId }}
+  clientId: {{ .Values.azure.clientId }}
+  clientSecret: {{ .Values.azure.clientSecret }}
 {{- end }}

--- a/chart/helm2/sops-secrets-operator/templates/azure_secret.yaml
+++ b/chart/helm2/sops-secrets-operator/templates/azure_secret.yaml
@@ -1,0 +1,15 @@
+{{- if and .Values.azure.enabled (not .Values.azure.svcAccExistingSecretName) }}
+kind: Secret
+apiVersion: v1
+metadata:
+  name: {{ include "sops-secrets-operator.name" . }}-azure-secret
+  labels:
+{{ include "sops-secrets-operator.labels" . | indent 4 }}
+    app.kubernetes.io/name: {{ include "sops-secrets-operator.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+type: Opaque
+stringData:
+  tenantId: {{ .Values.azure.svcAccTenantId }}
+  clientId: {{ .Values.azure.svcAccClientId }}
+  clientSecret: {{ .Values.azure.svcAccClientSecret }}
+{{- end }}

--- a/chart/helm2/sops-secrets-operator/templates/operator.yaml
+++ b/chart/helm2/sops-secrets-operator/templates/operator.yaml
@@ -76,6 +76,27 @@ spec:
             - name: GNUPGHOME
               value: /var/secrets/gpg
             {{- end }}
+            {{- if .Values.azure.enabled }}
+            {{- $secretname := printf "%s-azure-secret" (include "sops-secrets-operator.name" .) -}}
+            {{- if .Values.azure.svcAccExistingSecretName }}
+            {{- $secretname = .Values.azure.svcAccExistingSecretName -}}
+            {{- end }}
+            - name: AZURE_TENANT_ID
+              valueFrom:
+                secretKeyRef:
+                  name: {{ $secretname }}
+                  key: tenantId
+            - name: AZURE_CLIENT_ID
+              valueFrom:
+                secretKeyRef:
+                  name: {{ $secretname }}
+                  key: clientId
+            - name: AZURE_CLIENT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: {{ $secretname }}
+                  key: clientSecret
+            {{- end }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
       {{- if or .Values.gcp.enabled .Values.gpg.enabled }}

--- a/chart/helm2/sops-secrets-operator/templates/operator.yaml
+++ b/chart/helm2/sops-secrets-operator/templates/operator.yaml
@@ -78,8 +78,8 @@ spec:
             {{- end }}
             {{- if .Values.azure.enabled }}
             {{- $secretname := printf "%s-azure-secret" (include "sops-secrets-operator.name" .) -}}
-            {{- if .Values.azure.svcAccExistingSecretName }}
-            {{- $secretname = .Values.azure.svcAccExistingSecretName -}}
+            {{- if .Values.azure.existingSecretName }}
+            {{- $secretname = .Values.azure.existingSecretName -}}
             {{- end }}
             - name: AZURE_TENANT_ID
               valueFrom:

--- a/chart/helm2/sops-secrets-operator/values.yaml
+++ b/chart/helm2/sops-secrets-operator/values.yaml
@@ -31,7 +31,7 @@ gcp:
 
 # Azure KeyVault
 # If you enable this, you must either specify clientId, tenantId and clientSecret in values.yaml or you can reference
-# a secret you have created yourself via another means by specifying a name in svcAccExistingSecretName
+# a secret you have created yourself via another means by specifying a name in existingSecretName
 azure:
   enabled: false # if true Azure KeyVault will be used
   # Specify your credentials here or use existingSecretName below to use a pre-existing secret

--- a/chart/helm2/sops-secrets-operator/values.yaml
+++ b/chart/helm2/sops-secrets-operator/values.yaml
@@ -29,6 +29,18 @@ gcp:
   svcAccSecretCustomName: ''  # Name of the secret to create - will override default secret name if specified
   svcAccSecret: ''  # If `gcp.enabled` is `true`, this value must be specified as GCP service account secret json payload
 
+# Azure KeyVault
+# If you enable this, you must either specify clientId, tenantId and clientSecret in values.yaml or you can reference
+# a secret you have created yourself via another means by specifying a name in svcAccExistingSecretName
+azure:
+  enabled: false # if true Azure KeyVault will be used
+  # Specify your credentials here or use svcAccExistingSecretName below to use a pre-existing secret
+  svcAccTenantId: '' # TenantID of Azure Service principal to use
+  svcAccClientId: '' # ClientID (Application ID) of Azure Service Principal to use
+  svcAccClientSecret: '' # Client Secret of Azure Service Principal
+  # Pre-existing secret must contain the keys tenantId, clientId and clientSecret with the appropriate values
+  svcAccExistingSecretName: '' # Name of a pre-existing secret containing Azure Service Principal Credentials (ClientID, ClientSecret, TenantID)
+
 resources: {}  # Operator container resources
   # We usually recommend not to specify default resources and to leave this as a conscious
   # choice for the user. This also increases chances charts run on environments with little

--- a/chart/helm2/sops-secrets-operator/values.yaml
+++ b/chart/helm2/sops-secrets-operator/values.yaml
@@ -34,12 +34,12 @@ gcp:
 # a secret you have created yourself via another means by specifying a name in svcAccExistingSecretName
 azure:
   enabled: false # if true Azure KeyVault will be used
-  # Specify your credentials here or use svcAccExistingSecretName below to use a pre-existing secret
-  svcAccTenantId: '' # TenantID of Azure Service principal to use
-  svcAccClientId: '' # ClientID (Application ID) of Azure Service Principal to use
-  svcAccClientSecret: '' # Client Secret of Azure Service Principal
+  # Specify your credentials here or use existingSecretName below to use a pre-existing secret
+  tenantId: '' # TenantID of Azure Service principal to use
+  clientId: '' # ClientID (Application ID) of Azure Service Principal to use
+  clientSecret: '' # Client Secret of Azure Service Principal
   # Pre-existing secret must contain the keys tenantId, clientId and clientSecret with the appropriate values
-  svcAccExistingSecretName: '' # Name of a pre-existing secret containing Azure Service Principal Credentials (ClientID, ClientSecret, TenantID)
+  existingSecretName: '' # Name of a pre-existing secret containing Azure Service Principal Credentials (ClientID, ClientSecret, TenantID)
 
 resources: {}  # Operator container resources
   # We usually recommend not to specify default resources and to leave this as a conscious

--- a/chart/helm3/sops-secrets-operator/README.md
+++ b/chart/helm3/sops-secrets-operator/README.md
@@ -18,7 +18,7 @@ $ helm upgrade --install sops chart/sops-secrets-operator/ \
 * AWS is supported via `kiam` namespace and pod annotations or via [IAM roles for service accounts](https://docs.aws.amazon.com/eks/latest/userguide/specify-service-account-role.html)
 * GCP is supported via service account secret which allows decryption using GCP KMS
 * GPG is supported via secrets with GPG configuration
-* **TODO:** Azure support
+* Azure is supported via a Service principal plus a secret
 
 ## Introduction
 

--- a/chart/helm3/sops-secrets-operator/README.md
+++ b/chart/helm3/sops-secrets-operator/README.md
@@ -57,6 +57,14 @@ gcp:
 * Apply `sops-secrets-operator` CRD
 * Deploy helm chart specifying extra values file
 
+### Azure
+
+* Create a KeyVault if you don't have one already
+* Create a Key in that KeyVault
+* Create Service principal with permissions to use the key for Encryption/Decryption
+  * follow the [SOPS documentation](https://github.com/mozilla/sops#encrypting-using-azure-key-vault)
+* Either put Tenant ID, Client ID and Client Secret for the Service Principal in your custom values.yaml file or create a Kubernetes Secret with the same information and put the name of that secret in your values.yaml. Enable Azure in the Helm Chart by setting `azure.enabled: true` in values.yaml.
+
 ## Uninstalling the Chart
 
 To uninstall/delete the `my-release` deployment:
@@ -87,6 +95,11 @@ The following table lists the configurable parameters of the Sops-secrets-operat
 | `gcp.enabled` | Node labels for operator pod assignment | `false` |
 | `gcp.svcAccSecretCustomName` | Name of the secret to create - will override default secret name if specified | `""` |
 | `gcp.svcAccSecret` | If `gcp.enabled` is `true`, this value must be specified as gcp service account secret json payload | `""` |
+| `azure.enabled` | If `true` azure secret will used/created depending on other values set. | `false` |
+| `azure.tenantId`| Tenant ID of the Azure Service principal to use for Key access | `''` |
+| `azure.clientId`| Client (Application) ID of the Azure Service principal to use for Key access | `''` |
+| `azure.clientSecret`| Client Secret of the Azure Service principal to use for Key access | `''` |
+| `azure.existingSecretName`| If set the named secret will be used to find the Azure SP credentials. | `''` |
 | `resources` | Operator container resources | `{}` |
 | `nodeSelector` | Node selector to use for pod configuration | `{}` |
 | `securityContext.enabled` | Enable securitycontext | `false` |

--- a/chart/helm3/sops-secrets-operator/templates/azure_secret.yaml
+++ b/chart/helm3/sops-secrets-operator/templates/azure_secret.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.azure.enabled (not .Values.azure.svcAccExistingSecretName) }}
+{{- if and .Values.azure.enabled (not .Values.azure.existingSecretName) }}
 kind: Secret
 apiVersion: v1
 metadata:
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/instance: {{ .Release.Name }}
 type: Opaque
 stringData:
-  tenantId: {{ .Values.azure.svcAccTenantId }}
-  clientId: {{ .Values.azure.svcAccClientId }}
-  clientSecret: {{ .Values.azure.svcAccClientSecret }}
+  tenantId: {{ .Values.azure.tenantId }}
+  clientId: {{ .Values.azure.clientId }}
+  clientSecret: {{ .Values.azure.clientSecret }}
 {{- end }}

--- a/chart/helm3/sops-secrets-operator/templates/azure_secret.yaml
+++ b/chart/helm3/sops-secrets-operator/templates/azure_secret.yaml
@@ -1,0 +1,15 @@
+{{- if and .Values.azure.enabled (not .Values.azure.svcAccExistingSecretName) }}
+kind: Secret
+apiVersion: v1
+metadata:
+  name: {{ include "sops-secrets-operator.name" . }}-azure-secret
+  labels:
+{{ include "sops-secrets-operator.labels" . | indent 4 }}
+    app.kubernetes.io/name: {{ include "sops-secrets-operator.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+type: Opaque
+stringData:
+  tenantId: {{ .Values.azure.svcAccTenantId }}
+  clientId: {{ .Values.azure.svcAccClientId }}
+  clientSecret: {{ .Values.azure.svcAccClientSecret }}
+{{- end }}

--- a/chart/helm3/sops-secrets-operator/templates/operator.yaml
+++ b/chart/helm3/sops-secrets-operator/templates/operator.yaml
@@ -76,6 +76,27 @@ spec:
             - name: GNUPGHOME
               value: /var/secrets/gpg
             {{- end }}
+            {{- if .Values.azure.enabled }}
+            {{- $secretname := printf "%s-azure-secret" (include "sops-secrets-operator.name" .) -}}
+            {{- if .Values.azure.svcAccExistingSecretName }}
+            {{- $secretname = .Values.azure.svcAccExistingSecretName -}}
+            {{- end }}
+            - name: AZURE_TENANT_ID
+              valueFrom:
+                secretKeyRef:
+                  name: {{ $secretname }}
+                  key: tenantId
+            - name: AZURE_CLIENT_ID
+              valueFrom:
+                secretKeyRef:
+                  name: {{ $secretname }}
+                  key: clientId
+            - name: AZURE_CLIENT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: {{ $secretname }}
+                  key: clientSecret
+            {{- end }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
       {{- if or .Values.gcp.enabled .Values.gpg.enabled }}

--- a/chart/helm3/sops-secrets-operator/templates/operator.yaml
+++ b/chart/helm3/sops-secrets-operator/templates/operator.yaml
@@ -78,8 +78,8 @@ spec:
             {{- end }}
             {{- if .Values.azure.enabled }}
             {{- $secretname := printf "%s-azure-secret" (include "sops-secrets-operator.name" .) -}}
-            {{- if .Values.azure.svcAccExistingSecretName }}
-            {{- $secretname = .Values.azure.svcAccExistingSecretName -}}
+            {{- if .Values.azure.existingSecretName }}
+            {{- $secretname = .Values.azure.existingSecretName -}}
             {{- end }}
             - name: AZURE_TENANT_ID
               valueFrom:

--- a/chart/helm3/sops-secrets-operator/values.yaml
+++ b/chart/helm3/sops-secrets-operator/values.yaml
@@ -31,7 +31,7 @@ gcp:
 
 # Azure KeyVault
 # If you enable this, you must either specify clientId, tenantId and clientSecret in values.yaml or you can reference
-# a secret you have created yourself via another means by specifying a name in svcAccExistingSecretName
+# a secret you have created yourself via another means by specifying a name in existingSecretName
 azure:
   enabled: false # if true Azure KeyVault will be used
   # Specify your credentials here or use existingSecretName below to use a pre-existing secret

--- a/chart/helm3/sops-secrets-operator/values.yaml
+++ b/chart/helm3/sops-secrets-operator/values.yaml
@@ -29,6 +29,18 @@ gcp:
   svcAccSecretCustomName: ''  # Name of the secret to create - will override default secret name if specified
   svcAccSecret: ''  # If `gcp.enabled` is `true`, this value must be specified as GCP service account secret json payload
 
+# Azure KeyVault
+# If you enable this, you must either specify clientId, tenantId and clientSecret in values.yaml or you can reference
+# a secret you have created yourself via another means by specifying a name in svcAccExistingSecretName
+azure:
+  enabled: false # if true Azure KeyVault will be used
+  # Specify your credentials here or use svcAccExistingSecretName below to use a pre-existing secret
+  svcAccTenantId: '' # TenantID of Azure Service principal to use
+  svcAccClientId: '' # ClientID (Application ID) of Azure Service Principal to use
+  svcAccClientSecret: '' # Client Secret of Azure Service Principal
+  # Pre-existing secret must contain the keys tenantId, clientId and clientSecret with the appropriate values
+  svcAccExistingSecretName: '' # Name of a pre-existing secret containing Azure Service Principal Credentials (ClientID, ClientSecret, TenantID)
+
 resources: {}  # Operator container resources
   # We usually recommend not to specify default resources and to leave this as a conscious
   # choice for the user. This also increases chances charts run on environments with little

--- a/chart/helm3/sops-secrets-operator/values.yaml
+++ b/chart/helm3/sops-secrets-operator/values.yaml
@@ -34,12 +34,12 @@ gcp:
 # a secret you have created yourself via another means by specifying a name in svcAccExistingSecretName
 azure:
   enabled: false # if true Azure KeyVault will be used
-  # Specify your credentials here or use svcAccExistingSecretName below to use a pre-existing secret
-  svcAccTenantId: '' # TenantID of Azure Service principal to use
-  svcAccClientId: '' # ClientID (Application ID) of Azure Service Principal to use
-  svcAccClientSecret: '' # Client Secret of Azure Service Principal
+  # Specify your credentials here or use existingSecretName below to use a pre-existing secret
+  tenantId: '' # TenantID of Azure Service principal to use
+  clientId: '' # ClientID (Application ID) of Azure Service Principal to use
+  clientSecret: '' # Client Secret of Azure Service Principal
   # Pre-existing secret must contain the keys tenantId, clientId and clientSecret with the appropriate values
-  svcAccExistingSecretName: '' # Name of a pre-existing secret containing Azure Service Principal Credentials (ClientID, ClientSecret, TenantID)
+  existingSecretName: '' # Name of a pre-existing secret containing Azure Service Principal Credentials (ClientID, ClientSecret, TenantID)
 
 resources: {}  # Operator container resources
   # We usually recommend not to specify default resources and to leave this as a conscious


### PR DESCRIPTION
This PR implements Azure KeyVault support for the helm charts. Helm3 has been tested with minikube, helm2 chart was simply ported over from the changes to the helm3 chart, but not tested.

SOPS uses `az` CLI to talk to Azure, so to the best of my knowledge Auth does only work via environment variables, so this is what this PR uses. Environment variables are pulled from a secret which can either be explicitly generated by the Helm chart or one can provide a secret name, which one has to create themselves.

