### PR TITLE
fix: add gcp.existingSecretName value

### DIFF
--- a/chart/helm3/sops-secrets-operator/README.md
+++ b/chart/helm3/sops-secrets-operator/README.md
@@ -41,6 +41,8 @@ This chart bootstraps a [sops-secrets-operator](https://github.com/isindir/sops-
 ### GCP
 
 * Create GCP Service Account which allows to use KMS to decrypt
+* Either put the GCP Service Account JSON file in your custom values.yaml file or create a Kubernetes Secret with the same information and put the name of that secret in your values.yaml. Enable GCP in the Helm Chart by setting `gcp.enabled: true` in values.yaml.
+
 * Create custom values file in a following format:
 
 ```yaml
@@ -51,6 +53,14 @@ gcp:
       "type": "service_account",
       ...
     }
+```
+
+or 
+
+```yaml
+gcp:
+  enabled: true
+  existingSecretName: gcp-sa-existing-secret-name
 ```
 
 * Create Kubernetes namespace for operator deployment
@@ -108,6 +118,7 @@ The following table lists the configurable parameters of the Sops-secrets-operat
 | `gcp.enabled` | Node labels for operator pod assignment | `false` |
 | `gcp.svcAccSecretCustomName` | Name of the secret to create - will override default secret name if specified | `""` |
 | `gcp.svcAccSecret` | If `gcp.enabled` is `true`, this value must be specified as gcp service account secret json payload | `""` |
+| `gcp.existingSecretName` | Name of a pre-existing secret containing gcp service account secret json payload | `""` |
 | `azure.enabled` | If true azure keyvault will be used | `false` |
 | `azure.tenantId` | Tenantid of azure service principal to use | `""` |
 | `azure.clientId` | Clientid (application id) of azure service principal to use | `""` |

--- a/chart/helm3/sops-secrets-operator/templates/gcp_secret.yaml
+++ b/chart/helm3/sops-secrets-operator/templates/gcp_secret.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.gcp.enabled }}
+{{- if and .Values.gcp.enabled (not .Values.gcp.existingSecretName) }}
 kind: Secret
 apiVersion: v1
 metadata:

--- a/chart/helm3/sops-secrets-operator/templates/operator.yaml
+++ b/chart/helm3/sops-secrets-operator/templates/operator.yaml
@@ -122,7 +122,9 @@ spec:
       {{- if .Values.gcp.enabled }}
       - name: sops-operator-gke-svc-account
         secret:
-        {{- if .Values.gcp.svcAccSecretCustomName }}
+        {{- if .Values.gcp.existingSecretName }}
+          secretName: {{ .Values.gcp.existingSecretName }}
+        {{- else if .Values.gcp.svcAccSecretCustomName }}
           secretName: {{ .Values.gcp.svcAccSecretCustomName }}
         {{- else }}
           secretName: {{ include "sops-secrets-operator.name" . }}-gcp-secret

--- a/chart/helm3/sops-secrets-operator/values.yaml
+++ b/chart/helm3/sops-secrets-operator/values.yaml
@@ -30,6 +30,7 @@ gcp:
   enabled: false  # Node labels for operator pod assignment
   svcAccSecretCustomName: ''  # Name of the secret to create - will override default secret name if specified
   svcAccSecret: ''  # If `gcp.enabled` is `true`, this value must be specified as GCP service account secret json payload
+  existingSecretName: '' # Name of a pre-existing secret containing GCP service account secret json payload
 
 # Azure KeyVault
 # If you enable this, you must either specify clientId, tenantId and clientSecret in values.yaml or you can reference


### PR DESCRIPTION
#### What this PR does / why we need it:

This PR allows reusing an existing secret instead of letting the chart doing it.
  