### PR TITLE
Add the Role field for AWS KMS

### DIFF
--- a/api/v1alpha2/sopssecret_types.go
+++ b/api/v1alpha2/sopssecret_types.go
@@ -46,6 +46,8 @@ type KmsDataItem struct {
 	// Arn - KMS key ARN to use
 	// +optional
 	Arn string `json:"arn,omitempty"`
+	// +optional
+	Role string `json:"role,omitempty"`
 
 	// +optional
 	EncryptedKey string `json:"enc,omitempty"`

--- a/config/crd/bases/isindir.github.com_sopssecrets.yaml
+++ b/config/crd/bases/isindir.github.com_sopssecrets.yaml
@@ -127,6 +127,8 @@ spec:
                       type: string
                     enc:
                       type: string
+                    role:
+                      type: string
                   type: object
                 type: array
               lastmodified:


### PR DESCRIPTION
The "role" field tells sops to assume a different IAM role before accessing the KMS key.
This is required in my current setup.

I didn't want to bloat this PR, but note that there are some other fields that are defined by sops ([here](https://github.com/mozilla/sops/blob/e8d00046e1630dede664ebf9ebcd88d4fba59167/stores/stores.go)), but not forwarded by sops-secrets-operator ([here](https://github.com/isindir/sops-secrets-operator/blob/ca76076257678cc4ba825a919f1fa3c00e365579/api/v1alpha2/sopssecret_types.go)). I don't known which ones are relevant, but a quick check might be interesting.

BTW, thanks for this great tool!