### PR TITLE
feat: Allow custom secret types

### DIFF
--- a/config/age-test-key/00-raw-test-secrets.yaml
+++ b/config/age-test-key/00-raw-test-secrets.yaml
@@ -23,3 +23,8 @@ spec:
       type: 'kubernetes.io/dockerconfigjson'
       stringData:
         .dockerconfigjson: '{"auths":{"index.docker.io":{"username":"imyuser","password":"mypass","email":"myuser@abc.com","auth":"aW15dXNlcjpteXBhc3M="}}}'
+    - name: test-type-custom-secret-type
+      type: 'custom/type'
+      stringData:
+        username: some-username
+        password: 'some-password!'

--- a/config/age-test-key/00-test-secrets.yaml
+++ b/config/age-test-key/00-test-secrets.yaml
@@ -23,6 +23,11 @@ spec:
           type: ENC[AES256_GCM,data:rLjSr2aByTeACO2ucCj6h81qdS9QNmLs2QTB4wjJ,iv:KBmpgMCaK79uVdAsVxZMRqe1CQGDXxPESvwKtSPh6+s=,tag:s/4f6MnEIDoj1doDYUjaHQ==,type:str]
           stringData:
             .dockerconfigjson: ENC[AES256_GCM,data:EBB6l/PQVfEMCg6MYe1yUwGV8RxPyAUMom7DvtTDdce8lY1wztEWyrmCHPLXE/IkIq3/Iz6QTyyMFFBUERJovz5aYSwBAMeX6ocle9SG3wMWe1/cySYIQednL+PF1GWNUaIn1MEMO7PP1VopEuZSdWtHvXxfrubWC2mRMmhHaw==,iv:HV/C0ceSQcFveWzXBVZMfGSHV/bRBeB7ka/zxrHnrY8=,tag:HILN9fQBDbWFxjjnkBkp4Q==,type:str]
+        - name: ENC[AES256_GCM,data:s4jnBB5wPZ8ZLTlbmZ7ClwvhnMo9GX6cOy8CqQ==,iv:wv7Rnnf1KWSLeOAy1uB+eDRVzNUmaSAt1A14Gm7Q3SQ=,tag:6fejkzBv7aXzDIS3ueUSNg==,type:str]
+          type: ENC[AES256_GCM,data:5vi6NTNHWsO8hqE=,iv:5UwCj6ntDKYWFMHIijg8SLvXCDXxuPrDQBxV91eWizY=,tag:1XSPmM63vdrl5r/151kbfg==,type:str]
+          stringData:
+            username: ENC[AES256_GCM,data:HbwAwIhj6CElkHMpZg==,iv:McHE5IZ0EtYblv8LhwJwfE/W50Biq8FuT02ji+VWxaQ=,tag:0sUtO8rTVd7aDcDk5wZtFA==,type:str]
+            password: ENC[AES256_GCM,data:q+9LX8KsGQT5XDPzCrg=,iv:59TmGNnu2mGkMiqrT5Vg+COS8D3u3HbpluQAtyzH9fk=,tag:DxRE/zN4uN+TbT7H7kbzYw==,type:str]
 sops:
     kms: []
     gcp_kms: []
@@ -38,8 +43,8 @@ sops:
             YzlyY0NwQnptejk2RWpRV3RMUDVRWm8KDsF8k67qcYafOPIiAYVeQ+SvzLobq0pg
             h8OmBkNaahywzLTAjEcy8j84JRa1muAEJEX4fCLzE+7hsN+11Yc2gA==
             -----END AGE ENCRYPTED FILE-----
-    lastmodified: "2021-09-05T19:36:03Z"
-    mac: ENC[AES256_GCM,data:9K8gQB0RJXuVFeEzNg8Kuo++50xvdk8NR8Y0yIJTcjdcAAI+V733yRBBCLt8AzIERifUqI2geZcdKJeOq5mQ5Bg5WA5bqBowBXOmT9Oxmg7M0uUIbfoIV7X9hG42rTcZ+gBd8d3YFTAY4waFlgY7sTuJvacDt+cHJkh0a1+CGPY=,iv:F3DHuCUDrLpAHktYy2x5qkYbQf1gs0t8tFLv61YrEiU=,tag:Xdi7t78Z44T2j041CaCR8A==,type:str]
+    lastmodified: "2023-08-09T08:06:03Z"
+    mac: ENC[AES256_GCM,data:/GIB9ibqMFO71y9Mf0Jg87dsWXY4VJTQweNpVLhh3H0wYeZgZEG5+3g97Lah+UqEFhrHCXtH3ZiRanGLVgCz3jiFKEGOm56WyoA/Qn8NNRuH5k8KEOClFcC7vp0lSZ0xqcUhY+GoNQzybu4/K4MtSmMnwHfTXGKDZrjNPsuZF5g=,iv:VM818u90AEW5f/xSGKKgXZD4m0vZQhva7faoCTnYKOk=,tag:mC6f9l1YxHyKqFbCS4S70Q==,type:str]
     pgp: []
     encrypted_suffix: Templates
-    version: 3.7.1
+    version: 3.7.3

--- a/internal/controllers/sopssecret_controller.go
+++ b/internal/controllers/sopssecret_controller.go
@@ -410,28 +410,10 @@ func cloneTemplateData(stringData map[string]string, data map[string]string) (ma
 }
 
 func getSecretType(templateSecretType string) corev1.SecretType {
-	var kubeSecretType corev1.SecretType
-
-	switch templateSecretType {
-	case "kubernetes.io/service-account-token":
-		kubeSecretType = corev1.SecretTypeServiceAccountToken
-	case "kubernetes.io/dockercfg":
-		kubeSecretType = corev1.SecretTypeDockercfg
-	case "kubernetes.io/dockerconfigjson":
-		kubeSecretType = corev1.SecretTypeDockerConfigJson
-	case "kubernetes.io/basic-auth":
-		kubeSecretType = corev1.SecretTypeBasicAuth
-	case "kubernetes.io/ssh-auth":
-		kubeSecretType = corev1.SecretTypeSSHAuth
-	case "kubernetes.io/tls":
-		kubeSecretType = corev1.SecretTypeTLS
-	case "bootstrap.kubernetes.io/token":
-		kubeSecretType = corev1.SecretTypeBootstrapToken
-	default:
-		kubeSecretType = corev1.SecretTypeOpaque
+	if templateSecretType == "" {
+		return corev1.SecretTypeOpaque
 	}
-
-	return kubeSecretType
+	return corev1.SecretType(templateSecretType)
 }
 
 // decryptSopsSecretInstance decrypts spec.secretTemplates

--- a/internal/controllers/sopssecret_controller_test.go
+++ b/internal/controllers/sopssecret_controller_test.go
@@ -107,8 +107,8 @@ var _ = Describe("SopssecretController", func() {
 			listCommandOptions := &client.ListOptions{Namespace: "default"}
 			secretsList := &corev1.SecretList{}
 			Expect(controller.K8sClient.List(ctx, secretsList, listCommandOptions)).To(Succeed())
-			// 4 from SopsSecret object + 1 for Service Account
-			Expect(len(secretsList.Items)).To(Equal(4))
+			// 5 from SopsSecret object + 1 for Service Account
+			Expect(len(secretsList.Items)).To(Equal(5))
 
 			By("By checking content of token stringdata test secret")
 			testSecret := &corev1.Secret{}
@@ -125,6 +125,11 @@ var _ = Describe("SopssecretController", func() {
 			tagrgetSecretNamespacedName = &types.NamespacedName{Namespace: "default", Name: "test-type-docker-login"}
 			Expect(controller.K8sClient.Get(ctx, *tagrgetSecretNamespacedName, testSecret)).To(Succeed())
 			Expect(testSecret.Type).To(Equal(corev1.SecretTypeDockerConfigJson))
+
+			By("By checking custom secret type type")
+			tagrgetSecretNamespacedName = &types.NamespacedName{Namespace: "default", Name: "test-type-custom-secret-type"}
+			Expect(controller.K8sClient.Get(ctx, *tagrgetSecretNamespacedName, testSecret)).To(Succeed())
+			Expect(testSecret.Type).To(Equal(corev1.SecretType("custom/type")))
 
 			By("By checking jenkins test secret contains 1 label and 1 annotation")
 			tagrgetSecretNamespacedName = &types.NamespacedName{Namespace: "default", Name: "test-labels-annotations-jenkins-secret"}
@@ -168,8 +173,8 @@ var _ = Describe("SopssecretController", func() {
 			secretsList = &corev1.SecretList{}
 			Expect(controller.K8sClient.List(ctx, secretsList, listCommandOptions)).To(Succeed())
 
-			// 3 from SopsSecret object + 1 for Service Account
-			Expect(len(secretsList.Items)).To(Equal(3))
+			// 4 from SopsSecret object + 1 for Service Account
+			Expect(len(secretsList.Items)).To(Equal(4))
 			Expect(controller.K8sClient.Get(ctx, *sourceSopsSecretNamespacedName, sourceSopsSecret)).To(Succeed())
 			Expect(sourceSopsSecret.Status.Message).To(Equal("Healthy"))
 

--- a/internal/controllers/sopssecret_controller_test.go
+++ b/internal/controllers/sopssecret_controller_test.go
@@ -116,6 +116,9 @@ var _ = Describe("SopssecretController", func() {
 			Expect(controller.K8sClient.Get(ctx, *tagrgetSecretNamespacedName, testSecret)).To(Succeed())
 			Expect(string(testSecret.Data["token"])).To(Equal("Wb4ziZdELkdUf6m6KtNd7iRjjQRvSeJno5meH4NAGHFmpqJyEsekZ2WjX232s4Gj"))
 
+			By("By checking the secret type of test secret without an explicit type")
+			Expect(testSecret.Type).To(Equal(corev1.SecretTypeOpaque))
+
 			By("By checking content of token data test secret")
 			tagrgetSecretNamespacedName = &types.NamespacedName{Namespace: "default", Name: "test-data-token"}
 			Expect(controller.K8sClient.Get(ctx, *tagrgetSecretNamespacedName, testSecret)).To(Succeed())


### PR DESCRIPTION
#### What this PR does / why we need it:

Allows using custom secret types and not only the kubernetes provided ones