### PR TITLE
compare existing secret data with templated data instead of stringData

### DIFF
--- a/internal/controllers/sopssecret_controller.go
+++ b/internal/controllers/sopssecret_controller.go
@@ -6,6 +6,7 @@ package controllers
 
 import (
 	"context"
+	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -377,7 +378,7 @@ func createKubeSecretFromTemplate(
 			Labels:      labels,
 			Annotations: annotations,
 		},
-		Type:       kubeSecretType,
+		Type: kubeSecretType,
 		Data: Data,
 	}
 
@@ -398,7 +399,11 @@ func cloneMap(oldMap map[string]string) map[string]string {
 func cloneTemplateData(stringData map[string]string, data map[string]string) (map[string][]byte, error) {
 	processedData := map[string][]byte{}
 	for key, value := range data {
-		processedData[key] = []byte(value)
+		decoded, err := base64.StdEncoding.DecodeString(value)
+		if err != nil {
+			return nil, fmt.Errorf("createKubeSecretFromTemplate(): data[%v] is not a valid base64 string", key)
+		}
+		processedData[key] = []byte(decoded)
 	}
 	for key, value := range stringData {
 		processedData[key] = []byte(value)

--- a/internal/controllers/sopssecret_controller.go
+++ b/internal/controllers/sopssecret_controller.go
@@ -6,7 +6,6 @@ package controllers
 
 import (
 	"context"
-	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -402,8 +401,7 @@ func cloneTemplateData(stringData map[string]string, data map[string]string) (ma
 		processedData[key] = []byte(value)
 	}
 	for key, value := range stringData {
-		encoded := base64.StdEncoding.EncodeToString([]byte(value))
-		processedData[key] = []byte(encoded)
+		processedData[key] = []byte(value)
 	}
 	return processedData, nil
 }


### PR DESCRIPTION
#### What this PR does / why we need it:
This PR relates to https://github.com/isindir/sops-secrets-operator/issues/137

Right now the comparison done to determine if a secret needs to be updated clones the existing secret in kube, then performs some templating from the sopssecret object and checks the templated StringData against the secret in kube.
The problem is once applied a secret is applied in kube, the StringData content is encoded and added to Data, resulting in a wrong check from the operator, and in some edge cases can lead to a loop in reconciliation.

This PR fixes this behavior by templating what should be Data content in the secret object, and comparing it.

I'm not very familiar with go yet, so feel free to correct me / update the code.