### PR TITLE
fix: Disable reconcile loop on metadata/status changes of the CR sops object

### DIFF
--- a/internal/controllers/sopssecret_controller.go
+++ b/internal/controllers/sopssecret_controller.go
@@ -10,6 +10,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
 	"time"
 
 	"github.com/go-logr/logr"
@@ -344,6 +345,7 @@ func (r *SopsSecretReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&isindirv1alpha3.SopsSecret{}).
 		Owns(&corev1.Secret{}).
+		WithEventFilter(predicate.GenerationChangedPredicate{}).
 		Complete(r)
 }
 


### PR DESCRIPTION
… object

#### What this PR does / why we need it:
