### PR TITLE
docs: slightly better explanation for how to get the age decryption running

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,18 @@ helm upgrade --install sops sops/sops-secrets-operator --namespace sops
 ## Age
 
 * Create age reference `keys.txt` file, create kubernetes secret from it.
-* Deploy helm chart using `extraEnv` and `secretsAsFiles` to specify mounted `keys.txt` from secret via `SOPS_AGE_KEY_FILE` environment variable.
+* Deploy helm chart
+  - Use `secretsAsFiles` to specify the secret which contains the `keys.txt`. Example:
+  - Use `extraEnv` and specify mounted `keys.txt` path `SOPS_AGE_KEY_FILE` environment variable:
+```
+secretsAsFiles:
+- mountPath: /etc/sops-age-key-file
+  name: sops-age-key-file
+  secretName: sops-age-key-file
+extraEnv:
+- name: SOPS_AGE_KEY_FILE
+  value: /etc/sops-age-key-file/key
+```
 * Also see: [Local testing using age](docs/age/README.md)
 
 References:


### PR DESCRIPTION
#### What this PR does / why we need it:
Some minor improvements on how to get the age encryption working

Most other of using the operator have some examples but this one not. The description also doesn't explain that  `secretsAsFiles`  will actually create a mount for you rather than you having to create the mount separately (maybe that's a "Me issue", but having it say that won't hurt, right?)