### PR TITLE
feat: add more flexible security context configuration

### DIFF
--- a/chart/helm3/sops-secrets-operator/README.md
+++ b/chart/helm3/sops-secrets-operator/README.md
@@ -172,6 +172,10 @@ The following table lists the configurable parameters of the Sops-secrets-operat
 | serviceAccount.enabled | bool | `true` |  |
 | serviceAccount.name | string | `""` | Custom service account name to use instead of automatically generated name (if enabled - chart will generate SA, if not enabled - will use preconfigured) |
 | tolerations | list | `[]` | Tolerations to be applied to operator pod |
+| podSecurityContext.enabled | bool | `false` | Enable alternative flexible security context configuration |
+| podSecurityContext.* | object | `{}` | Flexible security context configuration. Mapped to `spec.securityContext` |
+| containerSecurityContext.enabled | bool | `false` | Enable alternative flexible security context configuration |
+| containerSecurityContext.* | object | `{}` | Flexible security context configuration. Mapped to `spec.containers[*].securityContext` and `spec.initContainers[*].securityContext` |
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,
 

--- a/chart/helm3/sops-secrets-operator/templates/operator.yaml
+++ b/chart/helm3/sops-secrets-operator/templates/operator.yaml
@@ -36,7 +36,10 @@ spec:
           image: "{{ .Values.initImage.repository }}:{{ .Values.initImage.tag }}"
           imagePullPolicy: {{ .Values.initImage.pullPolicy }}
           command: ['/bin/sh', '-c', 'cp -Lr /var/secrets/gpg-secrets/* /var/secrets/gpg/']
-          {{- if and .Values.securityContext.enabled .Values.securityContext.container.enabled }}
+          {{- if .Values.containerSecurityContext.enabled }}
+          securityContext:
+            {{- omit .Values.containerSecurityContext "enabled" | toYaml | nindent 12 }}
+          {{- else if and .Values.securityContext.enabled .Values.securityContext.container.enabled }}
           securityContext:
             capabilities:
               drop: {{ .Values.securityContext.container.capabilities.drop }}
@@ -54,7 +57,10 @@ spec:
         - name: {{ .Chart.Name }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
-          {{- if and .Values.securityContext.enabled .Values.securityContext.container.enabled }}
+          {{- if .Values.containerSecurityContext.enabled }}
+          securityContext:
+            {{- omit .Values.containerSecurityContext "enabled" | toYaml | nindent 12 }}
+          {{- else if and .Values.securityContext.enabled .Values.securityContext.container.enabled }}
           securityContext:
             capabilities:
               drop: {{ .Values.securityContext.container.capabilities.drop }}
@@ -192,7 +198,10 @@ spec:
       nodeSelector:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- if .Values.securityContext.enabled }}
+      {{- if .Values.podSecurityContext.enabled }}
+      securityContext:
+        {{- omit .Values.podSecurityContext "enabled" | toYaml | nindent 8 }}
+      {{- else if .Values.securityContext.enabled }}
       securityContext:
         runAsUser: {{ .Values.securityContext.runAsUser }}
         runAsGroup: {{ .Values.securityContext.runAsGroup }}

--- a/chart/helm3/sops-secrets-operator/values.yaml
+++ b/chart/helm3/sops-secrets-operator/values.yaml
@@ -180,6 +180,42 @@ securityContext:
       add:
       - NET_BIND_SERVICE
 
+# -- Pod-level Security Context (new - allows more flexible configuration)
+# When enabled, this takes precedence over the legacy securityContext fields above
+podSecurityContext:
+  # -- Enable flexible pod security context
+  enabled: false
+  # -- UID to run as
+  runAsUser: 65532
+  # -- GID to run as
+  runAsGroup: 65532
+  # -- fs group
+  fsGroup: 65532
+  # -- Enable kubelet validation for using root user to run container
+  runAsNonRoot: true
+  # -- seccomp profile configuration
+  seccompProfile:
+    type: RuntimeDefault
+  # Any other pod-level securityContext fields can be added here, e.g.:
+
+# -- Container-level Security Context (new flexible approach)
+# When enabled, this takes precedence over the legacy securityContext.container fields above
+containerSecurityContext:
+  # -- Enable flexible container security context
+  enabled: false
+  # -- Allow privilege escalation
+  allowPrivilegeEscalation: false
+  # -- Read-only root filesystem
+  readOnlyRootFilesystem: false
+  # -- capabilities configuration
+  capabilities:
+    drop:
+      - ALL
+  # Any other container-level securityContext fields can be added here, e.g.:
+  # runAsNonRoot: true
+  # runAsUser: 1000
+  # privileged: false
+
 # -- Tolerations to be applied to operator pod
 tolerations: []
 


### PR DESCRIPTION
#### What this PR does / why we need it:
Attempts to solve #216  in a backwards compatible way. I was unsure what the best way would be to handle this in a backwards compatible way, maybe this is the wrong way - appreciate any feedback! :)

`helm lint` has been run (`1 chart(s) linted, 0 chart(s) failed`)
