### PR TITLE
fix: change log level from Info to Error for unmarshalling

### DIFF
--- a/internal/controllers/sopssecret_controller.go
+++ b/internal/controllers/sopssecret_controller.go
@@ -505,7 +505,7 @@ func decryptSopsSecretInstance(
 	decryptedSopsSecret := &isindirv1alpha3.SopsSecret{}
 	err = json.Unmarshal(decryptedSopsSecretAsBytes, &decryptedSopsSecret)
 	if err != nil {
-		logger.V(0).Info(
+		logger.Error(
 			"Failed to Unmarshal decrypted sops secret decryptedSopsSecret",
 			"sopssecret", fmt.Sprintf("%s/%s", encryptedSopsSecret.Namespace, encryptedSopsSecret.Name),
 			"error", err,


### PR DESCRIPTION

#### Description

This should log as Error instead of Info so it's easier to set alerts based on these logs.

#### Suggested solution

There's other places that I think this should be done as well. Let me know if it makes sense and I can add those on this PR or on a different one.

