### PR TITLE
ci: Use docker-metadata to add standard opencontainer labels

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -29,6 +29,8 @@ jobs:
           echo "SOPS_SEC_OPERATOR_VERSION=$VERSION" >> $GITHUB_ENV
           SKIP_RELEASE=$(git tag -l "${VERSION}")
           echo "IMAGE_FULL_NAME=$(make image_full_name)" >> $GITHUB_ENV
+          echo "IMAGE_NAME=$(make image_name)" >> $GITHUB_ENV
+          echo "IMAGE_TAG=$(make image_tag)" >> $GITHUB_ENV
           echo "IMAGE_LATEST_NAME=$(make image_latest_name)" >> $GITHUB_ENV
           echo "IMAGE_CACHE_NAME=$(make image_cache_name)" >> $GITHUB_ENV
           echo "SKIP_RELEASE=${SKIP_RELEASE}" >> $GITHUB_ENV
@@ -80,6 +82,18 @@ jobs:
           gh release create "${SOPS_SEC_OPERATOR_VERSION}" -F chglog.tmp
 
       # UPDATE_HERE
+      # https://github.com/docker/metadata-action/releases
+      - name: Docker meta
+        id: meta
+        if: env.SKIP_RELEASE == ''
+        uses: docker/metadata-action@v6
+        with:
+          images: ${{ env.IMAGE_NAME }}
+          tags: |-
+            type=raw,value=${{ env.IMAGE_TAG }}
+            type=raw,value=latest
+
+      # UPDATE_HERE
       # https://github.com/docker/build-push-action/releases
       - name: Docker build
         if: env.SKIP_RELEASE == ''
@@ -87,7 +101,8 @@ jobs:
         with:
           context: .
           push: true
-          tags: ${{ env.IMAGE_LATEST_NAME }},${{ env.IMAGE_FULL_NAME }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
           platforms: linux/amd64,linux/arm64
           cache-from: type=registry,ref=${{ env.IMAGE_CACHE_NAME }}
           cache-to: type=registry,ref=${{ env.IMAGE_CACHE_NAME }},mode=max


### PR DESCRIPTION
#### Commit message

Please provide meaningfull commit message in a following format:

```
ci: Use docker-metadata to add standard opencontainer labels
```

#### Description

Using renovate to manage my infra as code, I like seeing changelogs in the PR requests when things change. When the labels are added to the image, renovate can look at github releases or commits to generate a change result. (would need to do 2 releases I think to fully see the change. latest and previous)

https://github.com/halkeye/home-k8s/pull/1138 is a kinda example

#### Suggested solution

N/A

#### Alternative solutions considered

I use docker-metadata most of the time, so i havn't really thought of too many other options. I would say manually adding the labels to dockerfile

#### Additional context

Add any other context or screenshots about the feature request/problem here.

#### AI generated code/design contribution

Please state if AI was used to directly generated PR code and/or if it has been used to create design of the suggested feature (including text in this issue request).
