### PR TITLE
feat: add mac_only_encrypted support to SopsSecret CRD

### DIFF
--- a/README.md
+++ b/README.md
@@ -274,6 +274,11 @@ sops --encrypt \
 > access to one of these is needed. For more information see `sops`
 > documentation.
 
+> **Note:** Files encrypted with `sops --mac-only-encrypted` are supported. The
+> resulting `sops.mac_only_encrypted: true` metadata field is recognised by the
+> CRD, so such resources pass strict server-side field validation when applied
+> with `kubectl apply` or `helm upgrade`.
+
 ## Changing ownership of existing secrets
 
 If there is a need to re-own existing `Secrets` by `SopsSecret`, following annotation should

--- a/api/v1alpha1/sopssecret_types.go
+++ b/api/v1alpha1/sopssecret_types.go
@@ -133,6 +133,11 @@ type SopsMetadata struct {
 	// Suffix used to encrypt SopsSecret resource
 	//+optional
 	EncryptedSuffix string `json:"encrypted_suffix,omitempty"`
+
+	// MacOnlyEncrypted - sops setting; when true the MAC is computed
+	// over values that end up encrypted only (sops --mac-only-encrypted).
+	//+optional
+	MacOnlyEncrypted bool `json:"mac_only_encrypted,omitempty"`
 }
 
 // SopsSecretStatus defines the observed state of SopsSecret

--- a/api/v1alpha2/sopssecret_types.go
+++ b/api/v1alpha2/sopssecret_types.go
@@ -172,6 +172,11 @@ type SopsMetadata struct {
 	// This opstion should be used with more care, as it can make resource unapplicable to the cluster.
 	//+optional
 	EncryptedRegex string `json:"encrypted_regex,omitempty"`
+
+	// MacOnlyEncrypted - sops setting; when true the MAC is computed
+	// over values that end up encrypted only (sops --mac-only-encrypted).
+	//+optional
+	MacOnlyEncrypted bool `json:"mac_only_encrypted,omitempty"`
 }
 
 // SopsSecretStatus defines the observed state of SopsSecret

--- a/api/v1alpha3/sopssecret_types.go
+++ b/api/v1alpha3/sopssecret_types.go
@@ -197,6 +197,11 @@ type SopsMetadata struct {
 	// This opstion should be used with more care, as it can make resource unapplicable to the cluster.
 	//+optional
 	EncryptedRegex string `json:"encrypted_regex,omitempty"`
+
+	// MacOnlyEncrypted - sops setting; when true the MAC is computed
+	// over values that end up encrypted only (sops --mac-only-encrypted).
+	//+optional
+	MacOnlyEncrypted bool `json:"mac_only_encrypted,omitempty"`
 }
 
 // SopsSecretStatus defines the observed state of SopsSecret

--- a/config/age-test-key/04-raw-test-secrets-mac-only.yaml
+++ b/config/age-test-key/04-raw-test-secrets-mac-only.yaml
@@ -1,0 +1,10 @@
+apiVersion: isindir.github.com/v1alpha3
+kind: SopsSecret
+metadata:
+  name: test-sopssecret-04
+  namespace: default
+spec:
+  secretTemplates:
+    - name: test-mac-only-token
+      stringData:
+        token: macOnlyEncryptedPlaintextValue1234567890

--- a/config/age-test-key/04-test-secrets-mac-only.yaml
+++ b/config/age-test-key/04-test-secrets-mac-only.yaml
@@ -1,0 +1,26 @@
+apiVersion: isindir.github.com/v1alpha3
+kind: SopsSecret
+metadata:
+    name: test-sopssecret-04
+    namespace: default
+spec:
+    secretTemplates:
+        - name: ENC[AES256_GCM,data:OcyTasfKtIVgxavKKM1sW1IWoQ==,iv:wgSlifca2Nc7PRjJjkzPyGjLsKJCkCwEsdubHOHc1D8=,tag:A4+F88r1xmBLZUJqkMkNbA==,type:str]
+          stringData:
+            token: ENC[AES256_GCM,data:fDRrIcURKBwHHAp5mb7SEpf78NseoQZPNDiRdzpoGGAxcZAmAqdAVQ==,iv:2+TNgi1ZTr5ZOILCzSHFTesfu4jcZGEHXmYOj4FNu/c=,tag:wCR83AguSKS48f4zrbEvMQ==,type:str]
+sops:
+    age:
+        - enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBCaDRxdEtjNnU3d3pGMXhL
+            VWZrK2c5dktIU2RmMnF0ckFIYjVpY2dTajN3Ci9jL1VMME5ueWdzamtIa05JOGVG
+            UU1nV3dPR29pZ05zdkx6azBuUVoxTmcKLS0tIFFPQ0RXMHBjcDd5bXVna211UVBL
+            clRObjI2MVMreHhLMUd0emc2ZFZxbmMKHW3Ou7Jk7r8OXJMnAiL8aWV3uBn6ojji
+            r/+OOd6RDQipWE7E0U1+tE6rj+Dpj6mpreoZLYroDAMs8xAulXUOww==
+            -----END AGE ENCRYPTED FILE-----
+          recipient: age1pnmp2nq5qx9z4lpmachyn2ld07xjumn98hpeq77e4glddu96zvms9nn7c8
+    encrypted_suffix: Templates
+    lastmodified: "2026-06-20T08:09:02Z"
+    mac: ENC[AES256_GCM,data:t8hic3QulKbFprmQVsdlUbmFdoFA3WoCE66xdViL7PJ7+I59XEaaFBKswkJ37ED102T4itJwo8OiHR5YSNF8UR9eTDmBUShKITvTYdKmv44/VE6MURjhSCyuPhq91DtZO2geyL13xUJwc4/X5LpfNz/rym8YldfKiHt+hwxYrF4=,iv:zJ+DjrC0Pwly1NfmIhpeO41c2fJhod6a1QlXNX4x9ss=,tag:eX0ej21SKCS+oxoDqTuC/w==,type:str]
+    mac_only_encrypted: true
+    version: 3.13.1

--- a/config/crd/bases/isindir.github.com_sopssecrets.yaml
+++ b/config/crd/bases/isindir.github.com_sopssecrets.yaml
@@ -103,6 +103,11 @@ spec:
               mac:
                 description: Mac - sops setting
                 type: string
+              mac_only_encrypted:
+                description: |-
+                  MacOnlyEncrypted - sops setting; when true the MAC is computed
+                  over values that end up encrypted only (sops --mac-only-encrypted).
+                type: boolean
               pgp:
                 description: PGP configuration
                 items:
@@ -306,6 +311,11 @@ spec:
               mac:
                 description: Mac - sops setting
                 type: string
+              mac_only_encrypted:
+                description: |-
+                  MacOnlyEncrypted - sops setting; when true the MAC is computed
+                  over values that end up encrypted only (sops --mac-only-encrypted).
+                type: boolean
               pgp:
                 description: PGP configuration
                 items:
@@ -512,6 +522,11 @@ spec:
               mac:
                 description: Mac - sops setting
                 type: string
+              mac_only_encrypted:
+                description: |-
+                  MacOnlyEncrypted - sops setting; when true the MAC is computed
+                  over values that end up encrypted only (sops --mac-only-encrypted).
+                type: boolean
               pgp:
                 description: PGP configuration
                 items:

--- a/internal/controllers/sopssecret_controller_test.go
+++ b/internal/controllers/sopssecret_controller_test.go
@@ -25,6 +25,7 @@ var _ = Describe("SopssecretController", func() {
 	TestSecretObject01 := &isindirv1alpha3.SopsSecret{}
 	TestSecretObject02 := &isindirv1alpha3.SopsSecret{}
 	TestSecretObject03 := &isindirv1alpha3.SopsSecret{}
+	TestSecretObject04 := &isindirv1alpha3.SopsSecret{}
 	BeforeEach(func() {
 		// 00 secret
 		content, err := os.ReadFile(filepath.Join("..", "..", "config", "age-test-key", "00-test-secrets.yaml"))
@@ -56,6 +57,14 @@ var _ = Describe("SopssecretController", func() {
 
 		obj, _, err = scheme.Codecs.UniversalDeserializer().Decode(content, nil, nil)
 		TestSecretObject03 = obj.(*isindirv1alpha3.SopsSecret)
+		Expect(err).Should(BeNil())
+
+		// 04 secret (encrypted with sops --mac-only-encrypted)
+		content, err = os.ReadFile(filepath.Join("..", "..", "config", "age-test-key", "04-test-secrets-mac-only.yaml"))
+		Expect(err).Should(BeNil())
+
+		obj, _, err = scheme.Codecs.UniversalDeserializer().Decode(content, nil, nil)
+		TestSecretObject04 = obj.(*isindirv1alpha3.SopsSecret)
 		Expect(err).Should(BeNil())
 	})
 
@@ -304,6 +313,38 @@ var _ = Describe("SopssecretController", func() {
 				}
 				return controller.K8sClient.Delete(ctx, secret)
 			}, timeout, interval).Should(Succeed())
+		})
+	})
+
+	Context("When Creating SopsSecret encrypted with --mac-only-encrypted", func() {
+		It("Should accept the object and decrypt the managed secret using SopsSecret 04", func() {
+			ctx := context.Background()
+
+			By("By creating a new SopsSecret version 04 with mac_only_encrypted set")
+			Expect(controller.K8sClient.Create(ctx, TestSecretObject04)).To(Succeed())
+
+			By("By checking that status of the SopsSecret is Healthy")
+			sourceSopsSecretNamespacedName := types.NamespacedName{Namespace: "default", Name: "test-sopssecret-04"}
+			Eventually(func(g Gomega) {
+				sourceSopsSecret := &isindirv1alpha3.SopsSecret{}
+				g.Expect(controller.K8sClient.Get(ctx, sourceSopsSecretNamespacedName, sourceSopsSecret)).To(Succeed())
+				g.Expect(sourceSopsSecret.Status.Message).To(Equal("Healthy"))
+				// Read the field back from the API server: a structural CRD
+				// prunes unknown fields, so this only stays true if the CRD
+				// schema actually carries mac_only_encrypted.
+				g.Expect(sourceSopsSecret.Sops.MacOnlyEncrypted).To(BeTrue())
+			}, timeout, interval).Should(Succeed())
+
+			By("By checking the decrypted content of the managed k8s secret")
+			managedSecretNamespacedName := types.NamespacedName{Namespace: "default", Name: "test-mac-only-token"}
+			Eventually(func(g Gomega) {
+				managedSecret := &corev1.Secret{}
+				g.Expect(controller.K8sClient.Get(ctx, managedSecretNamespacedName, managedSecret)).To(Succeed())
+				g.Expect(string(managedSecret.Data["token"])).To(Equal("macOnlyEncryptedPlaintextValue1234567890"))
+			}, timeout, interval).Should(Succeed())
+
+			By("By deleting SopsSecret version 04")
+			Expect(controller.K8sClient.Delete(ctx, TestSecretObject04)).To(Succeed())
 		})
 	})
 


### PR DESCRIPTION
We needed to encrypt SopsSecret resources with `sops --mac-only-encrypted` so that the MAC is computed only over the values that are actually encrypted. With this setting, structural fields such as `metadata.name`, labels and annotations stay out of the MAC checksum, so they can be templated and changed by Helm without invalidating the MAC. Without it, those fields take part in the MAC, so parameterizing them via Helm breaks the checksum.

The blocker was the CRD: `SopsMetadata` never declared the `mac_only_encrypted` field. Since the CRD uses a structural schema with no `preserveUnknownFields`, Kubernetes strict server-side field validation (the default since 1.25, used by `helm upgrade` and `kubectl apply`) rejects such manifests with `unknown field "mac_only_encrypted"` instead of pruning them. The failure surfaces at install/upgrade time, not at decryption — the operator already ignores the MAC, and in sops the flag only changes MAC computation, not per-value decryption.

This adds `mac_only_encrypted` as an optional field to `SopsMetadata` across all served API versions (v1alpha1, v1alpha2, v1alpha3) and regenerates the CRD. It is an additive, backward-compatible change, so no new API version or conversion is required. Existing manifests remain valid. An envtest spec with a `--mac-only-encrypted` fixture verifies the API server accepts the resource and the generated Secret decrypts correctly.