### PR TITLE
feat(chart): apply the namespace given to helm

### DIFF
--- a/chart/helm4/sops-secrets-operator/Chart.yaml
+++ b/chart/helm4/sops-secrets-operator/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 # UPDATE_HERE
-version: 0.27.1
+version: 0.27.2
 appVersion: 0.21.0
 type: application
 description: Helm chart deploys sops-secrets-operator

--- a/chart/helm4/sops-secrets-operator/README.md
+++ b/chart/helm4/sops-secrets-operator/README.md
@@ -135,7 +135,7 @@ The following table lists the configurable parameters of the Sops-secrets-operat
 | healthProbes.readiness | object | `{"initialDelaySeconds":5,"periodSeconds":10}` | Readiness probe configuration |
 | image.pullPolicy | string | `"Always"` | Operator image pull policy |
 | image.repository | string | `"quay.io/isindir/sops-secrets-operator"` | Operator image name |
-| image.tag | string | `"0.20.1"` | Operator image tag |
+| image.tag | string | `"0.21.0"` | Operator image tag |
 | imagePullSecrets | list | `[]` | Secrets to pull image from private docker repository |
 | initImage.pullPolicy | string | `"Always"` | Init container image pull policy |
 | initImage.repository | string | `"public.ecr.aws/ubuntu/ubuntu"` | Init container image name |
@@ -159,9 +159,11 @@ The following table lists the configurable parameters of the Sops-secrets-operat
 | resources | object | `{}` | Operator container resources |
 | secretsAsEnvVars | list | `[]` | configure custom secrets to be used as environment variables at runtime, see values.yaml |
 | secretsAsFiles | list | `[]` | configure custom secrets to be mounted at runtime, see values.yaml |
-| securityContext.container | object | `{"capabilities":{"add":["NET_BIND_SERVICE"],"drop":["all"]},"enabled":false}` | container/initContainer |
+| securityContext.container | object | `{"capabilities":{"add":["NET_BIND_SERVICE"],"drop":["all"]},"customContainerSecurityContext":{},"enabled":false}` | container/initContainer |
 | securityContext.container.capabilities | object | `{"add":["NET_BIND_SERVICE"],"drop":["all"]}` | capabilities |
+| securityContext.container.customContainerSecurityContext | object | `{}` (uses preconfigured defaults above) | Custom container securityContext override. When non-empty and container.enabled is true, this replaces the preconfigured container securityContext entirely. |
 | securityContext.container.enabled | bool | `false` | enables securityContext capabilities feature in containers |
+| securityContext.customPodSecurityContext | object | `{}` (uses preconfigured defaults above) | Custom pod securityContext override. When non-empty and securityContext.enabled is true, this replaces the preconfigured pod securityContext entirely. |
 | securityContext.enabled | bool | `false` | Enable securityContext |
 | securityContext.fsGroup | int | `13001` | fs group |
 | securityContext.runAsGroup | int | `13001` | GID to run as |

--- a/chart/helm4/sops-secrets-operator/templates/operator.yaml
+++ b/chart/helm4/sops-secrets-operator/templates/operator.yaml
@@ -4,6 +4,7 @@ metadata:
   name: {{ include "sops-secrets-operator.fullname" . }}
   labels:
 {{ include "sops-secrets-operator.labels" . | indent 4 }}
+  namespace: {{ .Release.Namespace }}
 spec:
   replicas: {{ .Values.replicaCount }}
   selector:

--- a/chart/helm4/sops-secrets-operator/tests/monitor_test.yaml
+++ b/chart/helm4/sops-secrets-operator/tests/monitor_test.yaml
@@ -56,5 +56,5 @@ tests:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: sops-secrets-operator
         app.kubernetes.io/version: "0.21.0"
-        helm.sh/chart: sops-secrets-operator-0.27.1
+        helm.sh/chart: sops-secrets-operator-0.27.2
         custom-label: custom-value

--- a/chart/helm4/sops-secrets-operator/tests/operator_test.yaml
+++ b/chart/helm4/sops-secrets-operator/tests/operator_test.yaml
@@ -31,7 +31,7 @@ tests:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: sops-secrets-operator
         app.kubernetes.io/version: 0.21.0
-        helm.sh/chart: sops-secrets-operator-0.27.1
+        helm.sh/chart: sops-secrets-operator-0.27.2
 
 # custom name
 - it: should correctly render custome name

--- a/chart/helm4/sops-secrets-operator/tests/service_account_test.yaml
+++ b/chart/helm4/sops-secrets-operator/tests/service_account_test.yaml
@@ -31,7 +31,7 @@ tests:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: sops-secrets-operator
         app.kubernetes.io/version: 0.21.0
-        helm.sh/chart: sops-secrets-operator-0.27.1
+        helm.sh/chart: sops-secrets-operator-0.27.2
 
 # custom name
 - it: should correctly render custome service account name

--- a/docs/index.yaml
+++ b/docs/index.yaml
@@ -20,6 +20,45 @@ entries:
       artifacthub.io/operatorCapabilities: Full Lifecycle
     apiVersion: v2
     appVersion: 0.21.0
+    created: "2026-06-24T23:10:53.886420897+02:00"
+    description: Helm chart deploys sops-secrets-operator
+    digest: 701969b4467a7b1da695b7f9f5f20c30cdfe1449d315fa6b59984c6fee62cbdf
+    keywords:
+    - gitops
+    - sops
+    - kms
+    - encryption
+    - secret
+    - git
+    maintainers:
+    - email: isindir@users.sf.net
+      name: isindir
+    name: sops-secrets-operator
+    sources:
+    - https://github.com/isindir/sops-secrets-operator.git
+    type: application
+    urls:
+    - https://isindir.github.io/sops-secrets-operator/sops-secrets-operator-0.27.2.tgz
+    version: 0.27.2
+  - annotations:
+      artifacthub.io/crds: |
+        - kind: SopsSecret
+          version: isindir.github.com/v1alpha3
+          name: sopssecret
+          displayName: SopsSecret
+          description: SopsSecret - encapsulates sops encrypted kubernetes secrets definitions
+      artifacthub.io/links: |
+        - name: "SOPS: Secrets OPerationS - Kubernetes Operator github project"
+          url: "https://github.com/isindir/sops-secrets-operator.git"
+        - name: "SOPS: Secrets OPerationS"
+          url: "https://github.com/mozilla/sops"
+      artifacthub.io/maintainers: |
+        - name: isindir
+          email: isindir@users.sf.net
+      artifacthub.io/operator: "true"
+      artifacthub.io/operatorCapabilities: Full Lifecycle
+    apiVersion: v2
+    appVersion: 0.21.0
     created: "2026-05-19T07:39:56.515868+01:00"
     description: Helm chart deploys sops-secrets-operator
     digest: a9666e5d34f156736dd5baa52f868ca3448616febfef87c5bb821cb474117437
@@ -2306,4 +2345,4 @@ entries:
     urls:
     - https://isindir.github.io/sops-secrets-operator/sops-secrets-operator-0.1.10.tgz
     version: 0.1.10
-generated: "2026-05-19T07:39:56.515005+01:00"
+generated: "2026-06-24T23:10:53.884153494+02:00"


### PR DESCRIPTION
#### Description

The chart ignored helm's `--namespace` parameter. This means that the deployment is always deployed to the current namespace - at least when helm is just rendering the manifest (like when using it with kustomize's `helmChart` inflater).

#### Suggested solution

Explicitly set the namespace for the deployment.

#### Alternative solutions considered

My personal alternative would be to craft a Kustomization patch that applies the namespace after the chart has been rendered.

#### AI generated code/design contribution

All changes have been done by me - a human (helped by the Make target `package-helm` and pre-commit) without any AI usage.