### PR TITLE
feat: support unencrypted_regex in SopsSecret metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -243,6 +243,24 @@ sops encrypt \
 > **NOTE:** after using regex `sops --encrypted-regex` resulting file may be inapplicable to the kubernetes cluster, use
 > this feature with care
 
+or, to keep the values which are not secret in plain text:
+
+```bash
+sops encrypt \
+  --kms 'arn:aws:kms:<region>:<account>:alias/<key-alias-name>' \
+  --unencrypted-regex='^(apiVersion|kind|metadata|status|name|LOG_LEVEL|PORT)$' jenkins-secrets.yaml \
+  > jenkins-secrets.enc.yaml
+```
+
+`sops --unencrypted-regex` encrypts all the values, except the values with a key that matches the
+regex. Use this option to keep configuration which is not secret readable in git, and to show the
+changes to that configuration in a diff. A new key is encrypted by default.
+
+> **NOTE:** the regex must also match `apiVersion`, `kind`, `metadata`, `status` and `name`.
+> Kubernetes adds fields to the resource when it stores the resource, for example `metadata.uid`
+> and `metadata.resourceVersion`. These fields are in plain text. If the regex does not match
+> them, the operator tries to decrypt them, and the reconciliation fails.
+
 - Encrypt file using `sops` and GCP KMS key:
 
 ```bash

--- a/api/v1alpha3/sopssecret_types.go
+++ b/api/v1alpha3/sopssecret_types.go
@@ -198,6 +198,14 @@ type SopsMetadata struct {
 	//+optional
 	EncryptedRegex string `json:"encrypted_regex,omitempty"`
 
+	// Regex used to select the values which stay unencrypted in SopsSecret resource.
+	// All the other values are encrypted. Use this option to keep non-secret
+	// configuration readable in git. The regex must also match apiVersion, kind,
+	// metadata, status and name, because Kubernetes adds plain text fields to the
+	// resource, for example metadata.uid.
+	//+optional
+	UnencryptedRegex string `json:"unencrypted_regex,omitempty"`
+
 	// MacOnlyEncrypted - sops setting; when true the MAC is computed
 	// over values that end up encrypted only (sops --mac-only-encrypted).
 	//+optional

--- a/config/age-test-key/05-raw-test-secrets-unencrypted-regex.yaml
+++ b/config/age-test-key/05-raw-test-secrets-unencrypted-regex.yaml
@@ -1,0 +1,11 @@
+apiVersion: isindir.github.com/v1alpha3
+kind: SopsSecret
+metadata:
+  name: test-sopssecret-05
+  namespace: default
+spec:
+  secretTemplates:
+    - name: test-partially-encrypted-05
+      stringData:
+        PLAIN_CONFIG_VALUE: someConfigValue
+        SECRET_TOKEN: someSecretToken

--- a/config/age-test-key/05-test-secrets-unencrypted-regex.yaml
+++ b/config/age-test-key/05-test-secrets-unencrypted-regex.yaml
@@ -1,0 +1,26 @@
+apiVersion: isindir.github.com/v1alpha3
+kind: SopsSecret
+metadata:
+    name: test-sopssecret-05
+    namespace: default
+spec:
+    secretTemplates:
+        - name: test-partially-encrypted-05
+          stringData:
+            PLAIN_CONFIG_VALUE: someConfigValue
+            SECRET_TOKEN: ENC[AES256_GCM,data:ggy07/8dqSNCv4npxc+b,iv:WG3SuqlyFl4pGBIJMIiHQW94DLcTDRUPxnDRs/ZhA5U=,tag:bLqhcNzcsHKM0hPFGeHbgA==,type:str]
+sops:
+    age:
+        - recipient: age1pnmp2nq5qx9z4lpmachyn2ld07xjumn98hpeq77e4glddu96zvms9nn7c8
+          enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBUVUIxMXNKNjlYaUV3ZXBi
+            d2ovOGFuc08zdjdZaUIrSzhVd3lIWmRNUGxvCkVDd1JhNk5YaDlxR0ZmREY5U1pq
+            b3BGSDFsMkZJcUFhTGdDSkJkclFnMUEKLS0tIE95KzlidDBEMzFNcm1lSEFndGk0
+            UFp0djdsVzYzMjNOaS85VUxJZ1hoNzAKg35Sg4i4vfbgRSxa5IEDWHSpmPvub+MZ
+            coAydWK2qGY2PukquJHYAJkdMvYG81m1p1X8s+a8ZU1k3bQewtO2OA==
+            -----END AGE ENCRYPTED FILE-----
+    lastmodified: "2026-08-06T22:49:48Z"
+    mac: ENC[AES256_GCM,data:VE2QaKCnp0wUgFZYg/p13P25306NDaOONsPzw+DtIJZE87cku1h/7Ej/tRJ5yPzukynn9PL+kEJe0GxTiFtIN7WJ7k8Oyuqt5Le++tMtl/72NvlTcyghYX4i42CbkGi943FlJ7ZWS/Qm102Kt7Wzdv6JiagDkhV6yuopn5hU9t4=,iv:GtuTXoGCaHxb7pGTV/Ns5GxZmP0jHES1nguXiJ8bFXE=,tag:uMf5KWHCTwnmFM4O1eesyg==,type:str]
+    unencrypted_regex: ^(apiVersion|kind|metadata|status|name|PLAIN_CONFIG_VALUE)$
+    version: 3.11.0

--- a/config/crd/bases/isindir.github.com_sopssecrets.yaml
+++ b/config/crd/bases/isindir.github.com_sopssecrets.yaml
@@ -543,6 +543,14 @@ spec:
                       type: string
                   type: object
                 type: array
+              unencrypted_regex:
+                description: |-
+                  Regex used to select the values which stay unencrypted in SopsSecret resource.
+                  All the other values are encrypted. Use this option to keep non-secret
+                  configuration readable in git. The regex must also match apiVersion, kind,
+                  metadata, status and name, because Kubernetes adds plain text fields to the
+                  resource, for example metadata.uid.
+                type: string
               version:
                 description: Version of the sops tool used to encrypt SopsSecret
                 type: string

--- a/internal/controllers/sopssecret_controller_test.go
+++ b/internal/controllers/sopssecret_controller_test.go
@@ -26,6 +26,7 @@ var _ = Describe("SopssecretController", func() {
 	TestSecretObject02 := &isindirv1alpha3.SopsSecret{}
 	TestSecretObject03 := &isindirv1alpha3.SopsSecret{}
 	TestSecretObject04 := &isindirv1alpha3.SopsSecret{}
+	TestSecretObject05 := &isindirv1alpha3.SopsSecret{}
 	BeforeEach(func() {
 		// 00 secret
 		content, err := os.ReadFile(filepath.Join("..", "..", "config", "age-test-key", "00-test-secrets.yaml"))
@@ -65,6 +66,14 @@ var _ = Describe("SopssecretController", func() {
 
 		obj, _, err = scheme.Codecs.UniversalDeserializer().Decode(content, nil, nil)
 		TestSecretObject04 = obj.(*isindirv1alpha3.SopsSecret)
+		Expect(err).Should(BeNil())
+
+		// 05 secret (encrypted with sops --unencrypted-regex)
+		content, err = os.ReadFile(filepath.Join("..", "..", "config", "age-test-key", "05-test-secrets-unencrypted-regex.yaml"))
+		Expect(err).Should(BeNil())
+
+		obj, _, err = scheme.Codecs.UniversalDeserializer().Decode(content, nil, nil)
+		TestSecretObject05 = obj.(*isindirv1alpha3.SopsSecret)
 		Expect(err).Should(BeNil())
 	})
 
@@ -345,6 +354,39 @@ var _ = Describe("SopssecretController", func() {
 
 			By("By deleting SopsSecret version 04")
 			Expect(controller.K8sClient.Delete(ctx, TestSecretObject04)).To(Succeed())
+		})
+	})
+
+	Context("When Creating SopsSecret encrypted with --unencrypted-regex", func() {
+		It("Should keep the allowlisted value in plain text and decrypt the other value using SopsSecret 05", func() {
+			ctx := context.Background()
+
+			By("By creating a new SopsSecret version 05 with unencrypted_regex set")
+			Expect(controller.K8sClient.Create(ctx, TestSecretObject05)).To(Succeed())
+
+			By("By checking that status of the SopsSecret is Healthy")
+			sourceSopsSecretNamespacedName := types.NamespacedName{Namespace: "default", Name: "test-sopssecret-05"}
+			Eventually(func(g Gomega) {
+				sourceSopsSecret := &isindirv1alpha3.SopsSecret{}
+				g.Expect(controller.K8sClient.Get(ctx, sourceSopsSecretNamespacedName, sourceSopsSecret)).To(Succeed())
+				g.Expect(sourceSopsSecret.Status.Message).To(Equal("Healthy"))
+				// Read the field back from the API server: a structural CRD
+				// prunes unknown fields, so this only stays true if the CRD
+				// schema actually carries unencrypted_regex.
+				g.Expect(sourceSopsSecret.Sops.UnencryptedRegex).To(Equal("^(apiVersion|kind|metadata|status|name|PLAIN_CONFIG_VALUE)$"))
+			}, timeout, interval).Should(Succeed())
+
+			By("By checking that the managed k8s secret holds the plain text value and the decrypted value")
+			managedSecretNamespacedName := types.NamespacedName{Namespace: "default", Name: "test-partially-encrypted-05"}
+			Eventually(func(g Gomega) {
+				managedSecret := &corev1.Secret{}
+				g.Expect(controller.K8sClient.Get(ctx, managedSecretNamespacedName, managedSecret)).To(Succeed())
+				g.Expect(string(managedSecret.Data["PLAIN_CONFIG_VALUE"])).To(Equal("someConfigValue"))
+				g.Expect(string(managedSecret.Data["SECRET_TOKEN"])).To(Equal("someSecretToken"))
+			}, timeout, interval).Should(Succeed())
+
+			By("By deleting SopsSecret version 05")
+			Expect(controller.K8sClient.Delete(ctx, TestSecretObject05)).To(Succeed())
 		})
 	})
 


### PR DESCRIPTION
#### Description

The CRD schema declares `encrypted_suffix` and `encrypted_regex`, but not `unencrypted_regex`. A structural CRD removes the fields which it does not declare, so the operator gets a resource with no crypt rule. `sops` then tries to decrypt every value, and it stops at the first plain text one:

```
Error walking tree: Could not decrypt value: Input string isindir.github.com/v1alpha3 does not match sops' data format
```

This makes it impossible to keep values which are not secret in plain text. Some `SopsSecret` resources might also hold a log level, a port or a hostname. Today those values need to be encrypted too, so a
reviewer sees only new cipher text in a diff.

`unencrypted_regex` is an allowlist, so `sops` still encrypts a new key by default.

#### Suggested solution

Add the field to `SopsMetadata` in `v1alpha3` and generate the CRD again.

The controller needs no change. The `sops` library already reads `unencrypted_regex` from the resource metadata; the field only has to pass through the API server. `mac_only_encrypted` is in the same structure for the same reason.

The regex must also match `apiVersion`, `kind`, `metadata`, `status` and `name`. Kubernetes adds plain text fields such as `metadata.uid`, and an allowlist encrypts everything it does not match. The README explains this.

#### Alternative solutions considered

- `encrypted_regex` with a list of the secret keys. It works today, but it is a denylist. A new secret goes to git in plain text if somebody forgets to update the regex.
- `unencrypted_comment_regex`. Comments are lost before the API server stores the object, so the operator never sees the markers. I tested this, and the decryption failed in the same manner.
- `unencrypted_suffix`. `sops` keeps the suffix in the key, so the child secret gets incorrect key names.

#### Additional context

`make test` passes, coverage 78.7%. The new test reads `sops.unencrypted_regex` back from the API server, in the same manner as the `mac_only_encrypted` test, so it fails if the schema drops the field.

The chart CRD is a symbolic link to the generated file, so it updates automatically. I did not add the field to `v1alpha1` and `v1alpha2`, which are deprecated, and I did not add the comment regex options, because a user who sets one gets an error which is difficult to diagnose.

#### AI generated code/design contribution

Yes. An AI assistant found the cause and wrote the code, the test and this description. I reviewed the change, cleaned up the description and ran the tests.
