### PR TITLE
docs: show a realistic unencrypted_regex example

### DIFF
--- a/README.md
+++ b/README.md
@@ -261,6 +261,48 @@ changes to that configuration in a diff. A new key is encrypted by default.
 > and `metadata.resourceVersion`. These fields are in plain text. If the regex does not match
 > them, the operator tries to decrypt them, and the reconciliation fails.
 
+A worked example. One application usually needs both secrets and configuration which is not
+secret. This `SopsSecret` holds five environment variables for one deployment:
+
+```yaml
+---
+apiVersion: isindir.github.com/v1alpha3
+kind: SopsSecret
+metadata:
+  name: my-app
+spec:
+  secretTemplates:
+    - name: my-app-env
+      stringData:
+        LOG_LEVEL: debug
+        WEB_CONCURRENCY: "4"
+        OTEL_EXPORTER_OTLP_ENDPOINT: https://otel.example.com:4318
+        DATABASE_URL: postgres://app:s3cr3t@db.example.com:5432/app
+        OPENAI_API_KEY: sk-example-not-a-real-key
+```
+
+Put the rule in `.sops.yaml`, so that the allowlist is in one file which the team reviews, and
+so that nobody has to repeat the flag:
+
+```yaml
+---
+creation_rules:
+  - path_regex: \.enc\.yaml$
+    unencrypted_regex: '^(apiVersion|kind|metadata|status|name|LOG_LEVEL|WEB_CONCURRENCY|OTEL_EXPORTER_OTLP_ENDPOINT)$'
+    kms: arn:aws:kms:<region>:<account>:alias/<key-alias-name>
+```
+
+After `sops encrypt`, the first three values stay readable and the last two are cipher text. A
+change to `WEB_CONCURRENCY` is then visible in the diff, and `DATABASE_URL` and `OPENAI_API_KEY`
+stay protected. A new key which the regex does not match is encrypted, so the default is safe.
+
+Values in `stringData` must stay quoted when they look like a number or a boolean, for example
+`WEB_CONCURRENCY: "4"`. Kubernetes only accepts strings in `stringData`.
+
+See `config/age-test-key/05-raw-test-secrets-unencrypted-regex.yaml` and
+`config/age-test-key/05-test-secrets-unencrypted-regex.yaml` for the same example before and
+after encryption.
+
 - Encrypt file using `sops` and GCP KMS key:
 
 ```bash

--- a/config/age-test-key/05-raw-test-secrets-unencrypted-regex.yaml
+++ b/config/age-test-key/05-raw-test-secrets-unencrypted-regex.yaml
@@ -7,5 +7,8 @@ spec:
   secretTemplates:
     - name: test-partially-encrypted-05
       stringData:
-        PLAIN_CONFIG_VALUE: someConfigValue
-        SECRET_TOKEN: someSecretToken
+        LOG_LEVEL: debug
+        WEB_CONCURRENCY: '4'
+        OTEL_EXPORTER_OTLP_ENDPOINT: https://otel.example.com:4318
+        DATABASE_URL: postgres://app:s3cr3t@db.example.com:5432/app
+        OPENAI_API_KEY: sk-example-not-a-real-key

--- a/config/age-test-key/05-test-secrets-unencrypted-regex.yaml
+++ b/config/age-test-key/05-test-secrets-unencrypted-regex.yaml
@@ -7,20 +7,23 @@ spec:
     secretTemplates:
         - name: test-partially-encrypted-05
           stringData:
-            PLAIN_CONFIG_VALUE: someConfigValue
-            SECRET_TOKEN: ENC[AES256_GCM,data:ggy07/8dqSNCv4npxc+b,iv:WG3SuqlyFl4pGBIJMIiHQW94DLcTDRUPxnDRs/ZhA5U=,tag:bLqhcNzcsHKM0hPFGeHbgA==,type:str]
+            LOG_LEVEL: debug
+            WEB_CONCURRENCY: "4"
+            OTEL_EXPORTER_OTLP_ENDPOINT: https://otel.example.com:4318
+            DATABASE_URL: ENC[AES256_GCM,data:CQyw/4a70BVSZUFngkJvma9xQ+qMHN4M31JQjxyJsNco6qrJOHikI50TTBk0,iv:uI2dSuBfivmf5l8T9Log2tJhf0Hk5EkGzPtTNirgZ1o=,tag:k6Y3wqERGn/q0jI/CxN/kg==,type:str]
+            OPENAI_API_KEY: ENC[AES256_GCM,data:kz4L5W7UxqvAmgYX+wqz8gKLS7fqxH/6aA==,iv:YOnuBS/GE0Vh/eDPXJ+Moff6aLdLrzguYoavHZuF0Ts=,tag:WfGhk6A9irlsH29ukne/DA==,type:str]
 sops:
     age:
         - recipient: age1pnmp2nq5qx9z4lpmachyn2ld07xjumn98hpeq77e4glddu96zvms9nn7c8
           enc: |
             -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBUVUIxMXNKNjlYaUV3ZXBi
-            d2ovOGFuc08zdjdZaUIrSzhVd3lIWmRNUGxvCkVDd1JhNk5YaDlxR0ZmREY5U1pq
-            b3BGSDFsMkZJcUFhTGdDSkJkclFnMUEKLS0tIE95KzlidDBEMzFNcm1lSEFndGk0
-            UFp0djdsVzYzMjNOaS85VUxJZ1hoNzAKg35Sg4i4vfbgRSxa5IEDWHSpmPvub+MZ
-            coAydWK2qGY2PukquJHYAJkdMvYG81m1p1X8s+a8ZU1k3bQewtO2OA==
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSA3UVNRQndjb2EvRE9VeTht
+            Z3VOQk1CZzJzbnAzZ0w2RUFYbzBSZEhrWFUwCmJ4bXYvTmE3TFh2cWx0WUhSTU9O
+            T3kxNUhLU0dPNFhDL0MyUXpaN3Zxdm8KLS0tIDF1ejFScXNzeXZVWk9McGRmV3Rx
+            ZlNOdUY1STloRGRROVlEUzNhaStxMkEKgnOsfejFz3jA5LAY6EaOx8M+OQh8aW/X
+            +h1FAutG0JK+f6M6+VcgWaf/NSYt/HaBw5ceRSCypIo45xFpjp0uIA==
             -----END AGE ENCRYPTED FILE-----
-    lastmodified: "2026-08-06T22:49:48Z"
-    mac: ENC[AES256_GCM,data:VE2QaKCnp0wUgFZYg/p13P25306NDaOONsPzw+DtIJZE87cku1h/7Ej/tRJ5yPzukynn9PL+kEJe0GxTiFtIN7WJ7k8Oyuqt5Le++tMtl/72NvlTcyghYX4i42CbkGi943FlJ7ZWS/Qm102Kt7Wzdv6JiagDkhV6yuopn5hU9t4=,iv:GtuTXoGCaHxb7pGTV/Ns5GxZmP0jHES1nguXiJ8bFXE=,tag:uMf5KWHCTwnmFM4O1eesyg==,type:str]
-    unencrypted_regex: ^(apiVersion|kind|metadata|status|name|PLAIN_CONFIG_VALUE)$
+    lastmodified: "2026-08-12T23:37:17Z"
+    mac: ENC[AES256_GCM,data:pSIBremiYHR4JLtZSY9/ffDBaKw36Jzk76daTPr0HoW1blw2KgH+yNnN+nfNVZQVhPd6qMfBtca4taxazViIKhcIrMVJjRRmEJEj9wpmvn3PsQ1sLUA7ZgC2SNUhSN/69NmuyapOySFv0XJGqgM8qO3upwgOqg2XUBF1wIY5mjk=,iv:TPWHTIqjKyTxpPpwnv28wvQnzzDkiks9QWg0ih6UPR4=,tag:83xW0v2bSZT9TA//6OMY1A==,type:str]
+    unencrypted_regex: ^(apiVersion|kind|metadata|status|name|LOG_LEVEL|WEB_CONCURRENCY|OTEL_EXPORTER_OTLP_ENDPOINT)$
     version: 3.11.0

--- a/internal/controllers/sopssecret_controller_test.go
+++ b/internal/controllers/sopssecret_controller_test.go
@@ -382,16 +382,23 @@ var _ = Describe("SopssecretController", func() {
 				// Read the field back from the API server: a structural CRD
 				// prunes unknown fields, so this only stays true if the CRD
 				// schema actually carries unencrypted_regex.
-				g.Expect(sourceSopsSecret.Sops.UnencryptedRegex).To(Equal("^(apiVersion|kind|metadata|status|name|PLAIN_CONFIG_VALUE)$"))
+				g.Expect(sourceSopsSecret.Sops.UnencryptedRegex).To(
+					Equal("^(apiVersion|kind|metadata|status|name|LOG_LEVEL|WEB_CONCURRENCY|OTEL_EXPORTER_OTLP_ENDPOINT)$"),
+				)
 			}, timeout, interval).Should(Succeed())
 
-			By("By checking that the managed k8s secret holds the plain text value and the decrypted value")
+			By("By checking that the managed k8s secret holds the plain text values and the decrypted values")
 			managedSecretNamespacedName := types.NamespacedName{Namespace: "default", Name: "test-partially-encrypted-05"}
 			Eventually(func(g Gomega) {
 				managedSecret := &corev1.Secret{}
 				g.Expect(controller.K8sClient.Get(ctx, managedSecretNamespacedName, managedSecret)).To(Succeed())
-				g.Expect(string(managedSecret.Data["PLAIN_CONFIG_VALUE"])).To(Equal("someConfigValue"))
-				g.Expect(string(managedSecret.Data["SECRET_TOKEN"])).To(Equal("someSecretToken"))
+				// values which the regex matches: in plain text in the git repository
+				g.Expect(string(managedSecret.Data["LOG_LEVEL"])).To(Equal("debug"))
+				g.Expect(string(managedSecret.Data["WEB_CONCURRENCY"])).To(Equal("4"))
+				g.Expect(string(managedSecret.Data["OTEL_EXPORTER_OTLP_ENDPOINT"])).To(Equal("https://otel.example.com:4318"))
+				// values which the regex does not match: encrypted in the git repository
+				g.Expect(string(managedSecret.Data["DATABASE_URL"])).To(Equal("postgres://app:s3cr3t@db.example.com:5432/app"))
+				g.Expect(string(managedSecret.Data["OPENAI_API_KEY"])).To(Equal("sk-example-not-a-real-key"))
 			}, timeout, interval).Should(Succeed())
 
 			By("By deleting SopsSecret version 05")


### PR DESCRIPTION
#### Commit message

`docs: show a realistic unencrypted_regex example`

#### Description

Follow up to #252. The example test does not make it clear why the feature is needed. The fixture used the key names `PLAIN_CONFIG_VALUE` and `SECRET_TOKEN`, which show the mechanism but not the use case. Read on its own, it does look like something a ConfigMap solves.

#### Suggested solution

The fixture now holds five environment variables for one application:

```yaml
stringData:
    LOG_LEVEL: debug
    WEB_CONCURRENCY: '4'
    OTEL_EXPORTER_OTLP_ENDPOINT: https://otel.example.com:4318
    DATABASE_URL: postgres://app:s3cr3t@db.example.com:5432/app
    OPENAI_API_KEY: sk-example-not-a-real-key
```

The first three stay in plain text and the last two are encrypted. This is the case the option is
for: one application with both types of value, in one file. A change to `WEB_CONCURRENCY` is then
visible in a diff, and the two secrets stay protected.

The README shows the same example, and it puts the rule in `.sops.yaml` instead of a command line
flag. This also answers your point about an incorrectly written regex: in `.sops.yaml` the allowlist
is one line in one file which the team reviews, instead of a flag which somebody retypes for each
file.

The README also states that a value in `stringData` must stay quoted when it looks like a number,
because Kubernetes only accepts strings there.

#### Alternative solutions considered

A ConfigMap mounted next to the secret holds this data equally well, and for the data alone it is
the simpler answer. The difference for us is the file, not the data. The same variables also live in
`.enc.env` files for local development and CI, so one `.sops.yaml` rule covers both places. A
ConfigMap solves only the cluster side, and then a person who adds one environment variable must
decide first whether it is secret, edit a second file, and add another `envFrom`.

#### Additional context

No change to the operator or to the CRD. This is the fixture, the assertions and the README.
`make test` passes, coverage 78.7%.

#### AI generated code/design contribution

Yes. An AI assistant wrote the example, the README text and this description. I reviewed the change
and ran the tests.
